### PR TITLE
Create date-check-blank-format.json

### DIFF
--- a/column-samples/date-check-blank-format/date-check-blank-format.json
+++ b/column-samples/date-check-blank-format/date-check-blank-format.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json",
+    "elmType": "div",
+    "txtContent": "=if(Number([$DueDate]) == 0, 'Blank Date' , if([$DueDate] < @now, 'Expired', 'Active'))",
+    "attributes": {
+        "class": "=if(Number([$DueDate]) == 0, 'sp-field-severity--warning' , if([$DueDate] < @now, 'sp-field-severity--blocked', 'sp-field-severity--good'))"
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New sample?      | yes
| Related issues?  | No

#### What's in this Pull Request?

Format a column when a date column is blank. Added JSON code file. This example populates the text content and applies different classes to the Status field depending on the value inside an item's DueDate field.
